### PR TITLE
Went from timer callback publish paradigm to publish as it comes para…

### DIFF
--- a/pollen_goto/pollen_goto/goto_action_server.py
+++ b/pollen_goto/pollen_goto/goto_action_server.py
@@ -1,4 +1,3 @@
-import collections
 import threading
 import time
 from queue import Queue
@@ -7,12 +6,15 @@ from threading import Event
 import numpy as np
 import rclpy
 from control_msgs.msg import DynamicJointState, InterfaceValue
-from pollen_msgs.action import Goto
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
-from rclpy.callback_groups import MutuallyExclusiveCallbackGroup, ReentrantCallbackGroup
+from rclpy.callback_groups import (
+    MutuallyExclusiveCallbackGroup,
+)  # ReentrantCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from sensor_msgs.msg import JointState
+
+from pollen_msgs.action import Goto
 
 from .interpolation import InterpolationMode
 


### PR DESCRIPTION
…digm

This was the first version of the implementation. When trying to debug the infamous 'rate' bug, I switched to the "timer callback publish paradigm", but it had several side effects that I didn't cover well at the time such as:
- It adds some delay between the moment the calculation is finished and the moment the value is published
- The goto server would always publish stuff (the last published value) (dumb mistake, was fixed)
- When asking a goto on e.g r_goto, the dynamic_joint_command covers all joints. For the joints outside the ongoing goto, the current value is spammed. So if you goto on the right_arm, you can't make a l_elbow.goal_position = 90 on the sdk for example.
- Other terrible stuff.

We can make this work with fixes, but avoiding this complexity was the point of the dynamic_state_router. Going back to the "publish as it comes" paradigm seems the most simple and robust implementation.

Are we ok with this?
