### PR TITLE
Working version with continuity safety

### DIFF
--- a/dynamic_state_router/dynamic_state_router/dynamic_state_router.py
+++ b/dynamic_state_router/dynamic_state_router/dynamic_state_router.py
@@ -55,7 +55,7 @@ class DynamicStateRouterNode(Node):
             qos_profile=5,
             callback=self.on_dynamic_joint_states,
         )
-        self.continuity_safety_on = False
+        self.continuity_safety_on = True
         # This safety is mostly here to detect discontinuities in the target position.
         # That's why we use a large detection speed but a small max speed if a discontinuity is detected.
         self.max_joint_velocity_threshold = 10.0  # rad/s


### PR DESCRIPTION
Ticket:
https://www.notion.so/pollen-robotics/Add-a-general-purpose-safety-in-ROS-level-5f3a4df4bc78476c9329cc7a163e2b11

This safety is mostly here to detect goal positions that are far from the present_position.
If a discontinuity is detected, a new, reduced, single goal position is output instead.

The impact it has is that a brutal order like this will almost be completely ignored (assuming the arm was in the resting position for example):
```
reachy.r_arm.elbow.pitch.goal_position = -90
```

Is this what we want?

Tested with the brutal elbow :
https://github.com/pollen-robotics/reachy2-sdk/blob/7a9c0221365fb067c0a5d6b929e412568dcc312a/src/example/basic_tests.py#L195

And the sinus joint : 
https://github.com/pollen-robotics/reachy2-sdk/blob/7a9c0221365fb067c0a5d6b929e412568dcc312a/src/example/basic_tests.py#L106

