### PR TITLE
enhancement #61: add ip address of webrtc container publishing ros img

### DIFF
--- a/cyclonedds.xml
+++ b/cyclonedds.xml
@@ -9,7 +9,7 @@
           <ParticipantIndex>auto</ParticipantIndex>
           <Peers>
               <Peer Address="localhost"/>
-              <Peer Address="172.18.0.5"/> 
+              <Peer Address="webrtc_streaming_playback_ros"/> 
           </Peers>
           <MaxAutoParticipantIndex>120</MaxAutoParticipantIndex>
       </Discovery>


### PR DESCRIPTION
ip address is defined here : https://github.com/pollen-robotics/docker_webrtc/pull/102
